### PR TITLE
feat!: Added supported for Firestore enterprise edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ Functional examples are included in the
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | backup\_schedule\_configuration | Backup schedule configuration for the Firestore Database. | <pre>object({<br>    weekly_recurrence = optional(object({<br>      day       = string<br>      retention = string<br>    }))<br><br>    daily_recurrence = optional(object({<br>      retention = string<br>    }))<br>  })</pre> | `null` | no |
-| composite\_index\_configuration | Composite index configuration for the Firestore Database. | <pre>list(object({<br>    index_id    = string<br>    collection  = string<br>    query_scope = optional(string, "COLLECTION")<br>    api_scope   = optional(string, "ANY_API")<br>    fields = list(object({<br>      field_path   = string<br>      order        = optional(string)<br>      array_config = optional(string)<br>      vector_config = optional(object({<br>        dimension = number<br>      }))<br>    }))<br>  }))</pre> | `[]` | no |
-| concurrency\_mode | Concurrency control mode to be used for the Firestore Database. | `string` | `"OPTIMISTIC"` | no |
+| composite\_index\_configuration | Composite index configuration for the Firestore Database. | <pre>list(object({<br>    index_id    = string<br>    collection  = string<br>    query_scope = optional(string, "COLLECTION")<br>    api_scope   = optional(string, "ANY_API")<br>    density     = optional(string)<br>    multikey    = optional(bool)<br>    fields = list(object({<br>      field_path   = string<br>      order        = optional(string)<br>      array_config = optional(string)<br>      vector_config = optional(object({<br>        dimension = number<br>      }))<br>    }))<br>  }))</pre> | `[]` | no |
+| concurrency\_mode | Concurrency control mode to be used for the Firestore Database. | `string` | `"PESSIMISTIC"` | no |
+| database\_edition | The database edition used to create the Firestore database. | `string` | `"STANDARD"` | no |
 | database\_id | Unique identifier of the Firestore Database. | `string` | n/a | yes |
 | database\_type | Database type used to created the Firestore Database. | `string` | `"FIRESTORE_NATIVE"` | no |
 | delete\_protection\_state | Determines whether deletion protection is enabled or not for the Firestore Database. | `string` | `"DELETE_PROTECTION_ENABLED"` | no |

--- a/examples/example_with_enterprise_edition/main.tf
+++ b/examples/example_with_enterprise_edition/main.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "firestore" {
+  source                            = "GoogleCloudPlatform/firestore/google"
+  version                           = "0.0.1"
+  project_id                        = var.project_id
+  database_id                       = "terraform-blueprint-enterprise-test"
+  location                          = "us-central1"
+  database_type                     = "FIRESTORE_NATIVE"
+  concurrency_mode                  = "PESSIMISTIC"
+  database_edition                  = "ENTERPRISE"
+  delete_protection_state           = "DELETE_PROTECTION_DISABLED"
+  point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_DISABLED"
+  deletion_policy                   = "DELETE"
+}

--- a/examples/example_with_enterprise_edition/outputs.tf
+++ b/examples/example_with_enterprise_edition/outputs.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "database_id" {
+  description = "Unique identifier of the created firestore database."
+  value       = module.firestore.database_id
+}

--- a/examples/example_with_enterprise_edition/variables.tf
+++ b/examples/example_with_enterprise_edition/variables.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which to provision resources."
+  type        = string
+}

--- a/examples/example_with_enterprise_edition/versions.tf
+++ b/examples/example_with_enterprise_edition/versions.tf
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/examples/example_with_enterprise_edition_and_indexes/main.tf
+++ b/examples/example_with_enterprise_edition_and_indexes/main.tf
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "firestore" {
+  source                            = "GoogleCloudPlatform/firestore/google"
+  version                           = "0.0.1"
+  project_id                        = var.project_id
+  database_id                       = "terraform-blueprint-enterprise-with-index-test"
+  location                          = "us-central1"
+  database_type                     = "FIRESTORE_NATIVE"
+  concurrency_mode                  = "PESSIMISTIC"
+  database_edition                  = "ENTERPRISE"
+  delete_protection_state           = "DELETE_PROTECTION_DISABLED"
+  point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_DISABLED"
+  deletion_policy                   = "DELETE"
+  composite_index_configuration = [
+    {
+      index_id    = "index1",
+      collection  = "test-collection-1"
+      api_scope   = "MONGODB_COMPATIBLE_API"
+      query_scope = "COLLECTION_GROUP"
+      density     = "DENSE"
+      fields = [
+        {
+          field_path = "field1",
+          order      = "ASCENDING"
+        },
+        {
+          field_path = "field2",
+          order      = "DESCENDING",
+        }
+      ]
+    },
+    {
+      index_id    = "index2",
+      collection  = "test-collection-2"
+      api_scope   = "MONGODB_COMPATIBLE_API"
+      query_scope = "COLLECTION_GROUP"
+      density     = "DENSE"
+      fields = [
+        {
+          field_path = "field3",
+          order      = "ASCENDING"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/example_with_enterprise_edition_and_indexes/outputs.tf
+++ b/examples/example_with_enterprise_edition_and_indexes/outputs.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "database_id" {
+  description = "Unique identifier of the created firestore database."
+  value       = module.firestore.database_id
+}

--- a/examples/example_with_enterprise_edition_and_indexes/variables.tf
+++ b/examples/example_with_enterprise_edition_and_indexes/variables.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which to provision resources."
+  type        = string
+}

--- a/examples/example_with_enterprise_edition_and_indexes/versions.tf
+++ b/examples/example_with_enterprise_edition_and_indexes/versions.tf
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ resource "google_firestore_database" "firestore_database" {
   concurrency_mode                  = var.concurrency_mode
   delete_protection_state           = var.delete_protection_state
   point_in_time_recovery_enablement = var.point_in_time_recovery_enablement
+  database_edition                  = var.database_edition
   deletion_policy                   = var.deletion_policy
 
   dynamic "cmek_config" {
@@ -60,6 +61,8 @@ resource "google_firestore_index" "firestore_index" {
   collection  = each.value.collection
   query_scope = each.value.query_scope
   api_scope   = each.value.api_scope
+  density     = each.value.density
+  multikey    = each.value.multikey
 
   dynamic "fields" {
     for_each = each.value.fields

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -43,6 +43,9 @@ spec:
               value: PESSIMISTIC
             - label: OPTIMISTIC_WITH_ENTITY_GROUPS
               value: OPTIMISTIC_WITH_ENTITY_GROUPS
+        database_edition:
+          name: database_edition
+          title: Database Edition
         database_id:
           name: database_id
           title: Database Id

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -39,6 +39,10 @@ spec:
         location: examples/example_with_backup
       - name: example_with_composite_indexes
         location: examples/example_with_composite_indexes
+      - name: example_with_enterprise_edition
+        location: examples/example_with_enterprise_edition
+      - name: example_with_enterprise_edition_and_indexes
+        location: examples/example_with_enterprise_edition_and_indexes
       - name: example_with_fields
         location: examples/example_with_fields
       - name: simple_example
@@ -61,10 +65,14 @@ spec:
         description: Database type used to created the Firestore Database.
         varType: string
         defaultValue: FIRESTORE_NATIVE
+      - name: database_edition
+        description: The database edition used to create the Firestore database.
+        varType: string
+        defaultValue: STANDARD
       - name: concurrency_mode
         description: Concurrency control mode to be used for the Firestore Database.
         varType: string
-        defaultValue: OPTIMISTIC
+        defaultValue: PESSIMISTIC
       - name: delete_protection_state
         description: Determines whether deletion protection is enabled or not for the Firestore Database.
         varType: string
@@ -101,6 +109,8 @@ spec:
               collection  = string
               query_scope = optional(string, "COLLECTION")
               api_scope   = optional(string, "ANY_API")
+              density     = optional(string)
+              multikey    = optional(bool)
               fields = list(object({
                 field_path   = string
                 order        = optional(string)

--- a/test/integration/example_with_enterprise_edition/example_with_enterprise_edition_test.go
+++ b/test/integration/example_with_enterprise_edition/example_with_enterprise_edition_test.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firestore_resource
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExampleWithEnterpriseEdition(t *testing.T) {
+	example := tft.NewTFBlueprintTest(t)
+
+	example.DefineVerify(func(assert *assert.Assertions) {
+		example.DefaultVerify(assert)
+
+		projectId := example.GetTFSetupStringOutput("project_id")
+		databaseId := example.GetStringOutput("database_id")
+
+		databaseIdPrefix := fmt.Sprintf("projects/%s/databases/", projectId)
+		databaseName := strings.TrimPrefix(databaseId, databaseIdPrefix)
+
+		databaseInfo := gcloud.Run(
+			t,
+			"firestore databases describe",
+			gcloud.WithCommonArgs([]string{"--project", projectId, "--database", databaseName, "--format", "json"}),
+		)
+
+		assert.Equal(
+			databaseId,
+			databaseInfo.Get("name").String(),
+			"Database ID does not match.",
+		)
+
+		assert.Equal(
+			"ENTERPRISE",
+			databaseInfo.Get("databaseEdition").String(),
+			"Expected enterprise database edition.",
+		)
+
+		assert.Equal(
+			"FIRESTORE_NATIVE",
+			databaseInfo.Get("type").String(),
+			"Expected firestore native database.",
+		)
+
+		assert.Equal(
+			"us-central1",
+			databaseInfo.Get("locationId").String(),
+			"Expected database to be created in us-central1 region.",
+		)
+
+		assert.Equal(
+			"PESSIMISTIC",
+			databaseInfo.Get("concurrencyMode").String(),
+			"Expected pessimistic concurrency mode.",
+		)
+	})
+	example.Test()
+}

--- a/test/integration/example_with_enterprise_edition_and_indexes/example_with_enterprise_edition_and_indexes_test.go
+++ b/test/integration/example_with_enterprise_edition_and_indexes/example_with_enterprise_edition_and_indexes_test.go
@@ -1,0 +1,186 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firestore_resource
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/stretchr/testify/assert"
+)
+
+type IndexInfo struct {
+	Fields     []IndexField `json:"fields"`
+	Name       string       `json:"name"`
+	QueryScope string       `json:"queryScope"`
+	ApiScope   string       `json:"apiScope"`
+	State      string       `json:"state"`
+	Density    string       `json:"density"`
+}
+
+type IndexField struct {
+	FieldPath string `json:"fieldPath"`
+	Order     string `json:"order"`
+}
+
+func extractCollectionGroupName(indexName string) string {
+	re := regexp.MustCompile(`projects/[^/]+/databases/[^/]+/collectionGroups/([^/]+)/indexes/[^/]+`)
+	match := re.FindStringSubmatch(indexName)
+	if len(match) == 2 {
+		return match[1]
+	}
+
+	return ""
+}
+
+func TestExampleWithEnterpriseEditionAndIndexes(t *testing.T) {
+	example := tft.NewTFBlueprintTest(t)
+
+	example.DefineVerify(func(assert *assert.Assertions) {
+		example.DefaultVerify(assert)
+
+		projectId := example.GetTFSetupStringOutput("project_id")
+		databaseId := example.GetStringOutput("database_id")
+
+		databaseIdPrefix := fmt.Sprintf("projects/%s/databases/", projectId)
+		databaseName := strings.TrimPrefix(databaseId, databaseIdPrefix)
+
+		databaseInfo := gcloud.Run(
+			t,
+			"firestore databases describe",
+			gcloud.WithCommonArgs([]string{"--project", projectId, "--database", databaseName, "--format", "json"}),
+		)
+
+		indexInfo := gcloud.Run(
+			t,
+			"firestore indexes composite list",
+			gcloud.WithCommonArgs([]string{"--project", projectId, "--database", databaseName, "--format", "json"}),
+		).String()
+
+		var indexList []IndexInfo
+		json.Unmarshal([]byte(indexInfo), &indexList)
+
+		expectedIndexes := make(map[string][][]IndexField)
+		expectedIndexes["test-collection-1"] = [][]IndexField{
+			[]IndexField{
+				IndexField{
+					FieldPath: "field1",
+					Order:     "ASCENDING",
+				},
+				IndexField{
+					FieldPath: "field2",
+					Order:     "DESCENDING",
+				},
+			},
+		}
+
+		expectedIndexes["test-collection-2"] = [][]IndexField{
+			[]IndexField{
+				IndexField{
+					FieldPath: "field3",
+					Order:     "ASCENDING",
+				},
+			},
+		}
+
+		assert.Equal(
+			databaseId,
+			databaseInfo.Get("name").String(),
+			"Database ID does not match.",
+		)
+
+		assert.Equal(
+			"ENTERPRISE",
+			databaseInfo.Get("databaseEdition").String(),
+			"Expected enterprise database edition.",
+		)
+
+		assert.Equal(
+			"FIRESTORE_NATIVE",
+			databaseInfo.Get("type").String(),
+			"Expected firestore native database.",
+		)
+
+		assert.Equal(
+			"us-central1",
+			databaseInfo.Get("locationId").String(),
+			"Expected database to be created in us-central1 region.",
+		)
+
+		assert.Equal(
+			"PESSIMISTIC",
+			databaseInfo.Get("concurrencyMode").String(),
+			"Expected pessimistic concurrency mode.",
+		)
+
+		assert.Equal(
+			2,
+			len(indexList),
+		)
+
+		actualIndexes := make(map[string][][]IndexField)
+		for _, index := range indexList {
+			assert.Equal(
+				"COLLECTION_GROUP",
+				index.QueryScope,
+			)
+
+			assert.Equal(
+				"MONGODB_COMPATIBLE_API",
+				index.ApiScope,
+			)
+
+			assert.Equal(
+				"DENSE",
+				index.Density,
+			)
+
+			collectionGroupName := extractCollectionGroupName(index.Name)
+			_, ok := actualIndexes[collectionGroupName]
+			if !ok {
+				actualIndexes[collectionGroupName] = [][]IndexField{}
+			}
+
+			actualIndexes[collectionGroupName] = append(actualIndexes[collectionGroupName], index.Fields)
+		}
+
+		assert.Equal(
+			1,
+			len(actualIndexes["test-collection-1"]),
+		)
+
+		assert.Equal(
+			1,
+			len(actualIndexes["test-collection-2"]),
+		)
+
+		assert.Equal(
+			expectedIndexes["test-collection-1"],
+			actualIndexes["test-collection-1"],
+		)
+
+		assert.Equal(
+			expectedIndexes["test-collection-2"],
+			actualIndexes["test-collection-2"],
+		)
+
+	})
+	example.Test()
+}


### PR DESCRIPTION
Adding support for firestore enterprise edition in the CFT blueprint.
This PR contains the following changes:

* New variable added to specify database edition.
* Default concurrency mode changed to PESSIMISTIC since this is the only mode supported in enterprise edition.
* Options to provide density and multikey index when creating an index.
* Integration tests for DB and index creation in enterprise mode.
* README and metadata file changes.