### PR TITLE
feat: Update Google provider version constraint to < 8 for Firestore

### DIFF
--- a/examples/example_with_backup/main.tf
+++ b/examples/example_with_backup/main.tf
@@ -16,7 +16,7 @@
 
 module "firestore" {
   source                            = "GoogleCloudPlatform/firestore/google"
-  version                           = "0.0.1"
+  version                           = ">= 0.0.1"
   project_id                        = var.project_id
   database_id                       = "terraform-blueprint-backup-test"
   location                          = "us-central1"

--- a/examples/example_with_composite_indexes/main.tf
+++ b/examples/example_with_composite_indexes/main.tf
@@ -16,7 +16,7 @@
 
 module "firestore" {
   source                            = "GoogleCloudPlatform/firestore/google"
-  version                           = "0.0.1"
+  version                           = ">= 0.0.1"
   project_id                        = var.project_id
   database_id                       = "terraform-blueprint-composite-index-test"
   location                          = "us-central1"

--- a/examples/example_with_enterprise_edition/main.tf
+++ b/examples/example_with_enterprise_edition/main.tf
@@ -16,7 +16,7 @@
 
 module "firestore" {
   source                            = "GoogleCloudPlatform/firestore/google"
-  version                           = "0.0.1"
+  version                           = ">= 0.0.1"
   project_id                        = var.project_id
   database_id                       = "terraform-blueprint-enterprise-test"
   location                          = "us-central1"

--- a/examples/example_with_enterprise_edition_and_indexes/main.tf
+++ b/examples/example_with_enterprise_edition_and_indexes/main.tf
@@ -16,7 +16,7 @@
 
 module "firestore" {
   source                            = "GoogleCloudPlatform/firestore/google"
-  version                           = "0.0.1"
+  version                           = ">= 0.0.1"
   project_id                        = var.project_id
   database_id                       = "terraform-blueprint-enterprise-with-index-test"
   location                          = "us-central1"

--- a/examples/example_with_fields/main.tf
+++ b/examples/example_with_fields/main.tf
@@ -16,7 +16,7 @@
 
 module "firestore" {
   source                            = "GoogleCloudPlatform/firestore/google"
-  version                           = "0.0.1"
+  version                           = ">= 0.0.1"
   project_id                        = var.project_id
   database_id                       = "terraform-blueprint-field-test"
   location                          = "us-central1"

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -16,7 +16,7 @@
 
 module "firestore" {
   source                            = "GoogleCloudPlatform/firestore/google"
-  version                           = "0.0.1"
+  version                           = ">= 0.0.1"
   project_id                        = var.project_id
   database_id                       = "terraform-blueprint-test"
   location                          = "us-central1"

--- a/versions.tf
+++ b/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53, < 7"
+      version = ">= 3.53, < 8"
     }
   }
 


### PR DESCRIPTION
feat: Update Google provider version constraint to < 8

This is being done to resolve error related to version incompatibility while deploying connection between vertex-ai-agent-engine and firestore.

Firestore metadata schema validation successfully done:
https://paste.googleplex.com/5974071425761280


Successful connection deployment in staging:

vertex-ai-agent-engine & firestore:
app deployment: https://screenshot.googleplex.com/7LhfvWjpfQisqoh
Connection params: https://screenshot.googleplex.com/5XMd2TnCayBYT6u